### PR TITLE
Add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+#ignore LaTeX build files
+*.aux
+*.log
+*.out
+*.synctex.gz
+*.toc
+
+#might also want to ignore compiled pdfs (only track source)
+#*.pdf


### PR DESCRIPTION
This avoids tracking auxiliary build files (`.aux`, etc.) that LaTeX generates during compiling.

If accepted, you might want to delete the ones there already (`main.aux`, etc.) I would add it to this pull request but I'm on the web client and I'm not sure how to do that.

Another option is to also avoid tracking the generated PDFs, but you might want to keep those so people can view them without building the PDF themselves.